### PR TITLE
Fix typo w/ ExtraSpace Install in README.md

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    extraspace (0.5.0)
+    extraspace (0.6.0)
       http
       json
       nokogiri

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-gem install extrapsace
+gem install extraspace
 ```
 
 ## Configuration

--- a/lib/extraspace/version.rb
+++ b/lib/extraspace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExtraSpace
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
Fixes typo w/ `gem install ...` in README.md.