### PR TITLE
Fix Typo in Module Containing `FetchError`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    extraspace (1.0.1)
+    extraspace (1.0.2)
       http
       json
       nokogiri

--- a/lib/extraspace/fetch_error.rb
+++ b/lib/extraspace/fetch_error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ExrtaSpace
+module ExtraSpace
   # Raised for unexpected HTTP responses.
   class FetchError < StandardError
     # @param url [String]

--- a/lib/extraspace/version.rb
+++ b/lib/extraspace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExtraSpace
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
This fixes a typo in the module causing issues when attempting to bump the dependency.