### PR TITLE
Handle `nil` `lastmod` For Some Sitemap Entries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    extraspace (1.0.2)
+    extraspace (1.0.3)
       http
       json
       nokogiri

--- a/lib/extraspace/link.rb
+++ b/lib/extraspace/link.rb
@@ -15,7 +15,7 @@ module ExtraSpace
     # @param lastmod [String]
     def initialize(loc:, lastmod:)
       @loc = loc
-      @lastmod = Time.parse(lastmod)
+      @lastmod = Time.parse(lastmod) if lastmod
     end
 
     # @return [String]

--- a/lib/extraspace/version.rb
+++ b/lib/extraspace/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExtraSpace
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Some entries in the sitemap recently began to contain a `nil` `lastmod`. This avoids parsing if the `lastmod` isn't configured. For example:

https://www.extraspace.com/storage/facilities/us/florida/pensacola/1961